### PR TITLE
Add instructions for Containerized Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,16 @@ Read more on the [uWSGI Metrics subsystem] for further explanation on metrics pr
 [DogStatsD]: http://docs.datadoghq.com/guides/dogstatsd/
 [uWSGI]: http://uwsgi-docs.readthedocs.org/
 [uWSGI Metrics subsystem]: http://uwsgi-docs.readthedocs.org/en/latest/Metrics.html
+
+### Note on Containerized Docker Agent
+To make use of this stats-pusher, you must enable dogstatsd and **enable non-local traffic**. You must set two config values via environment variables or config file:
+1. Environment Variables
+    ```
+     DD_USE_DOGSTATSD=true
+     DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true
+    ```
+2. Config yaml
+    ```
+     dogstatsd_stats_enable: true
+     dogstatsd_non_local_traffic: true
+    ```


### PR DESCRIPTION
I was recently trying to deploy this plugin into an API environment and was not receiving metrics in Datadog.

I have a multi-container deployment set up with docker-compose, and I was trying to send metrics from my application container (where uWSGI is running) to my dd-agent which is in a separate container (same docker network). I followed the instructions and didn't see any worrisome logs from uWSGI or the agent, but still nothing was coming through.

Eventually I noticed that dogstatsd was listening on `127.0.0.1:8125` in the dd-agent container, and noticed the documentation [here](https://docs.datadoghq.com/containers/docker/?tab=standard#dogstatsd-custom-metrics) mentioning "non-local" traffic. After configuring dogstatsd to listen for "non-local" traffic, dogstatsd was listening correctly to outside traffic and metrics began coming in. Yay!

I thought it might be helpful to include a small note in the usage instructions here so that anyone attempting something similar in the future might save some troubleshooting time. Happy to take feedback or amend what I've added.