### PR TITLE
Fix cumulative metrics being incorrectly sent as counters

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -94,14 +94,6 @@ class Test(threading.Thread):
         'myapp.worker.respawns'
     ]
 
-    # Metrics that should be sent as gauges (|g) instead of counters (|c)
-    GAUGE_METRICS = [
-        'myapp.worker.requests',
-        'myapp.worker.respawns',
-        'myapp.worker.total_tx',
-        'myapp.worker.core.requests'
-    ]
-
     VAL_METRICS = {
         'myapp.worker.avg_response_time': (50, 250)
     }
@@ -146,16 +138,15 @@ class Test(threading.Thread):
                     self.failure += 1
                     self.errors.append(k)
 
-            # Verify that metrics are sent as gauges
+            # Verify that ALL metrics are sent as gauges (|g), not counters (|c)
             all_data = self.data.get_data()
-            for k in self.GAUGE_METRICS:
-                if k in all_data:
-                    if all_data[k]['metric_type'] == 'g':
-                        self.success += 1
-                    else:
-                        self.setExitValue(1)
-                        self.failure += 1
-                        self.errors.append(k + ' (wrong type: ' + all_data[k]['metric_type'] + ')')
+            for k, v in all_data.iteritems():
+                if v['metric_type'] == 'g':
+                    self.success += 1
+                else:
+                    self.setExitValue(1)
+                    self.failure += 1
+                    self.errors.append(k + ' (wrong type: ' + v['metric_type'] + ', expected g)')
 
         self.oldData = attributes_changed
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -94,6 +94,14 @@ class Test(threading.Thread):
         'myapp.worker.respawns'
     ]
 
+    # Metrics that should be sent as gauges (|g) instead of counters (|c)
+    GAUGE_METRICS = [
+        'myapp.worker.requests',
+        'myapp.worker.respawns',
+        'myapp.worker.total_tx',
+        'myapp.worker.core.requests'
+    ]
+
     VAL_METRICS = {
         'myapp.worker.avg_response_time': (50, 250)
     }
@@ -137,6 +145,17 @@ class Test(threading.Thread):
                     self.setExitValue(1)
                     self.failure += 1
                     self.errors.append(k)
+
+            # Verify that metrics are sent as gauges
+            all_data = self.data.get_data()
+            for k in self.GAUGE_METRICS:
+                if k in all_data:
+                    if all_data[k]['metric_type'] == 'g':
+                        self.success += 1
+                    else:
+                        self.setExitValue(1)
+                        self.failure += 1
+                        self.errors.append(k + ' (wrong type: ' + all_data[k]['metric_type'] + ')')
 
         self.oldData = attributes_changed
 


### PR DESCRIPTION
## Summary

Fixes #18 

DogStatsD counters sum all values received during a flush period, which causes cumulative metrics like `worker.respawns` to be reported incorrectly. 

For example, if `worker.respawns=3` is pushed 5 times per flush period, DogStatsD would report 15 instead of 3.

## Changes

This PR modifies the plugin to send all uwsgi metrics as DogStatsD gauges (|g) instead of counters (|c). Gauges report the last received value, which correctly represents:
- **Cumulative metrics**: requests, respawns, bytes transmitted
- **Snapshot metrics**: memory usage, worker count

## Why This Works

**DogStatsD Counter Behavior:**
- Sums all values during flush period
- `metric:5|c` sent 3 times = reports 15

**DogStatsD Gauge Behavior:**
- Uses last value received
- `metric:5|g` sent 3 times = reports 5

Since uwsgi pushes the same metric value repeatedly until it changes, gauges are the correct type for all uwsgi metrics.

## Testing

Updated test suite to verify metrics are sent with the correct type (|g).

🤖 Generated with [Claude Code](https://claude.com/claude-code)